### PR TITLE
Simplified lisp-unit interface.

### DIFF
--- a/tests/collectors.lisp
+++ b/tests/collectors.lisp
@@ -111,4 +111,4 @@
     (test 1 2 3 4)
     (assert-equal '(2 2 4 2 4 6 2 4 6 8) (test))))
 
-(run-tests)
+(run-tests :all)


### PR DESCRIPTION
The lisp-unit interface has been simplified. This pull will update the call to run-tests to conform to the new interface.
